### PR TITLE
Fix Deprecated version of ember-cli-htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tour"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-htmlbars": "1.1.1",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Update ember-cli-handlebars version to >= 1.1.0 to fix the following deprecation warning that shows up after upgrading to Ember 2.6.0:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
  at Function.Addon.lookup (.../node_modules/ember-cli/lib/models/addon.js:1005:27)
```

The Issue outlined here: ember-cli/ember-cli-htmlbars#77